### PR TITLE
Use relative path for Sonatype

### DIFF
--- a/src/main/java/io/spring/concourse/releasescripts/sonatype/SonatypeService.java
+++ b/src/main/java/io/spring/concourse/releasescripts/sonatype/SonatypeService.java
@@ -16,7 +16,6 @@
 
 package io.spring.concourse.releasescripts.sonatype;
 
-import java.net.URI;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
@@ -93,11 +92,12 @@ public class SonatypeService {
 		this.artifactCollector = new ArtifactCollector(sonatypeProperties.getExclude());
 	}
 
-	private URI buildMarkerArtifactSha1URI(ReleaseInfo releaseInfo) {
+	private String buildMarkerArtifactSha1URI(ReleaseInfo releaseInfo) {
 		ReleaseInfo.MarkerArtifact markerArtifact = releaseInfo.getMarkerArtifact();
 		return UriComponentsBuilder.fromPath(NEXUS_REPOSITORY_PATH).path(markerArtifact.getGroupId().replace('.', '/'))
 				.path("/{artifactId}/{version}/{artifactId}-{version}.jar.sha1").build(markerArtifact.getArtifactId(),
-						markerArtifact.getVersion(), markerArtifact.getArtifactId(), markerArtifact.getVersion());
+						markerArtifact.getVersion(), markerArtifact.getArtifactId(), markerArtifact.getVersion())
+				.toString();
 	}
 
 	/**


### PR DESCRIPTION
fixes #18 

Changed 'buildMarkerArtifactSha1URI' to return String instead of URI.
That way RestTemplate can compose the url with the root set during init.

@wilkinsona point to the fact that the same [change](https://github.com/spring-projects/spring-boot/commit/7617f0df60cc79e6cbd08f14ff043ac0b50130c8) uses String in Spring Boot repo, and this seems to fix the problem here too.
