### PR TITLE
Improve publishToCentral argument validation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -67,7 +67,7 @@ The Concourse Release Scripts application supports several commands:
 [source,sh,subs="verbatim,attributes"]
 .Command example
 ----
-java -jar /spring-boot-release-scripts.jar $COMMAND $RELEASE_TYPE $BUILD_INFO_LOCATION
+java -jar /concourse-release-scripts.jar $COMMAND $RELEASE_TYPE $BUILD_INFO_LOCATION
 ----
 
 Where:
@@ -86,7 +86,7 @@ The repository is then closed and, upon successful closure, it is released.
 [source,sh,subs="verbatim,attributes"]
 .Command example
 ----
-java -jar /spring-boot-release-scripts.jar publishToMavenCentral $RELEASE_TYPE $BUILD_INFO_LOCATION $ARTIFACTS_LOCATION
+java -jar /concourse-release-scripts.jar publishToCentral $RELEASE_TYPE $BUILD_INFO_LOCATION $ARTIFACTS_LOCATION
 ----
 
 Where:
@@ -123,7 +123,7 @@ This command sends a request to the Artifactory REST API to promote artifacts fr
 [source,sh,subs="verbatim,attributes"]
 .Command example
 ----
-java -jar /spring-boot-release-scripts.jar publishToSdkman $RELEASE_TYPE $VERSION $BRANCH
+java -jar /concourse-release-scripts.jar publishToSdkman $RELEASE_TYPE $VERSION $BRANCH
 ----
 
 Where:

--- a/src/main/java/io/spring/concourse/releasescripts/command/ArgumentValidator.java
+++ b/src/main/java/io/spring/concourse/releasescripts/command/ArgumentValidator.java
@@ -1,0 +1,35 @@
+package io.spring.concourse.releasescripts.command;
+
+import org.springframework.util.Assert;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringJoiner;
+
+/**
+ * Simple argument validator. It expects arguments to be in a fixed order and position.
+ *
+ * @author Andy Wilkinson
+ */
+public class ArgumentValidator {
+
+	private final List<String> expectedArguments;
+
+	public ArgumentValidator(String... expectedArgumentsNames) {
+		Assert.notEmpty(expectedArgumentsNames, "arguments must not be null or empty");
+		this.expectedArguments = Arrays.asList(expectedArgumentsNames);
+	}
+
+	public void validate(List<String> args) {
+		if (args.size() < expectedArguments.size() && args.size() != expectedArguments.size()) {
+			throw new IllegalArgumentException("Missing argument(s): " + joinFrom(expectedArguments, args.size()));
+		}
+	}
+
+	private String joinFrom(List<String> expectedArguments, int from) {
+		StringJoiner stringJoiner = new StringJoiner(", ");
+		expectedArguments.subList(from, expectedArguments.size()).forEach(stringJoiner::add);
+		return stringJoiner.toString();
+	}
+
+}

--- a/src/main/java/io/spring/concourse/releasescripts/command/PublishToCentralCommand.java
+++ b/src/main/java/io/spring/concourse/releasescripts/command/PublishToCentralCommand.java
@@ -16,10 +16,6 @@
 
 package io.spring.concourse.releasescripts.command;
 
-import java.io.File;
-import java.nio.file.Files;
-import java.util.List;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.spring.concourse.releasescripts.ReleaseInfo;
 import io.spring.concourse.releasescripts.ReleaseType;
@@ -28,10 +24,12 @@ import io.spring.concourse.releasescripts.artifactory.payload.BuildInfoResponse.
 import io.spring.concourse.releasescripts.sonatype.SonatypeService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.stereotype.Component;
-import org.springframework.util.Assert;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.List;
 
 /**
  * Command used to publish a release to Maven Central.
@@ -60,8 +58,8 @@ public class PublishToCentralCommand implements Command {
 	@Override
 	public void run(ApplicationArguments args) throws Exception {
 		List<String> nonOptionArgs = args.getNonOptionArgs();
-		Assert.state(nonOptionArgs.size() == 4,
-				"Release type, build info location, or artifacts location not specified");
+		new ArgumentValidator(getName(), "RELEASE_TYPE", "BUILD_INFO_LOCATION", "ARTIFACTS_LOCATION")
+				.validate(nonOptionArgs);
 		String releaseType = nonOptionArgs.get(1);
 		ReleaseType type = ReleaseType.from(releaseType);
 		if (!ReleaseType.RELEASE.equals(type)) {

--- a/src/test/java/io/spring/concourse/releasescripts/command/ArgumentValidatorTest.java
+++ b/src/test/java/io/spring/concourse/releasescripts/command/ArgumentValidatorTest.java
@@ -1,0 +1,44 @@
+package io.spring.concourse.releasescripts.command;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+/**
+ * Tests for {@link ArgumentValidator}.
+ *
+ * @author Abel Salgado Romero
+ */
+public class ArgumentValidatorTest {
+
+	@Test
+	public void shouldFailWhenArgumentsAreLessThanRequired() {
+		ArgumentValidator argumentValidator = new ArgumentValidator("$ONE", "$TWO", "$THREE");
+
+		Throwable failure = catchThrowable(() -> argumentValidator.validate(Arrays.asList("first", "second")));
+
+		assertThat(failure).isInstanceOf(IllegalArgumentException.class).hasMessage("Missing argument(s): $THREE");
+	}
+
+	@Test
+	public void shouldNotFailWhenArgumentsAreMoreThanRequired() {
+		ArgumentValidator argumentValidator = new ArgumentValidator("one");
+
+		argumentValidator.validate(Arrays.asList("first", "second"));
+	}
+
+	@Test
+	public void shouldFailAndReportAllMissingArguments() {
+		ArgumentValidator argumentValidator = new ArgumentValidator("$ONE", "$TWO", "$THREE");
+
+		Throwable failure = catchThrowable(() -> argumentValidator.validate(Collections.emptyList()));
+
+		assertThat(failure).isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Missing argument(s): $ONE, $TWO, $THREE");
+	}
+
+}


### PR DESCRIPTION
Reports wich arguments are missing instead of general message 'Release type, build info location, or artifacts location not specified'.

I tried to keep it simple, just report missing ones based on names from README.
This is motivated because we recently had a bash typo that affected arguments and the previous message did not provide much help.

Also:
* Fixes in README 